### PR TITLE
fix: np.int is deprecated

### DIFF
--- a/MTH2210/EDO/euler.py
+++ b/MTH2210/EDO/euler.py
@@ -29,7 +29,7 @@ def check_parameters_consistency(f, x0, t0, tm, m, output):
                     [x0,     "x0",     [np.ndarray, np.float64]],
                     [t0,     "t0",     np.float64],
                     [tm,     "tm",     np.float64],
-                    [m,      "m",      np.int],
+                    [m,      "m",      int],
                     [output, "output", str]]
     check_type_arguments.check_parameters(params_array)
     # Vérification de la cohérence des paramètres
@@ -76,7 +76,7 @@ def format_iter(k, x_k, t_k):
             header = ""
         iter_infos = "{:>4} || {:>+11.4e} | {:>+9.4f}"
         iter_infos = iter_infos.format(k, x_k, t_k)
-    
+
     else:
         if k == 0:
             n = len(x_k)
@@ -90,7 +90,7 @@ def format_iter(k, x_k, t_k):
             header = ""
         iter_infos  = "{:>4} || ".format(k)
         iter_infos += "["+", ".join(["{:>+11.4e}".format(xi) for xi in x_k])+"] | "+"{:>+9.4f}".format(t_k)
-    
+
     return(header+iter_infos)
 
 
@@ -141,13 +141,13 @@ def euler(f, x0, t0, tm, m, output=""):
         - x_0 donné, t_0 donné, pas de temps h donné,
         - x_kp1 = x_k + h*f(x_k,t_k),
         - t_kp1 = t_k + h.
-    
+
     Les arguments attendus sont :
         - une fonction f, admettant en entrée un vecteur x et un réel t, renvoyant un vecteur f(x,t),
         - un vecteur  x0, condition initiale de l'équation,
         - deux réels  t0 et tm, les bornes de l'intervalle de temps sur lequel l'équation est appliquée,
         - un entier    m, le pas de discrétisation de [t0,tm], définissant donc h = (tm-t0)/m.
-    
+
     L'argument optionnel est une chaîne de caractères output (défaut = "") qui renvoie les affichages de la fonction vers :
         - la sortie standard si output = "pipe",
         - un fichier ayant pour nom+extension output (le paramètre doit donc contenir l'extension voulue, et le chemin d'accès doit exister),
@@ -157,7 +157,7 @@ def euler(f, x0, t0, tm, m, output=""):
         - la fonction f est définie en (x0,t0) et en (x0,tm),
         - f(x0,t0) renvoie un vecteur de la même dimension et même type que x0,
         - tous les paramètres reçus ont bien le type attendu.
-    
+
     À noter que si x est un vecteur de dim 1, f doit être implémentée avec parcimonie pour ne pas renvoyer un mauvais type. Par exemple :
         - x = np.array(0) est un np.ndarray, x = np.array([0]) également,
         - f(x,t) = np.cos(np.array(0))   est un np.float64,
@@ -173,11 +173,11 @@ def euler(f, x0, t0, tm, m, output=""):
         - cas sans garantie de fonctionnement correct :
             - x      complexe,
             - x      de dimension 1 défini par un np.array([valeur]).
-    
+
     Les sorties de la méthode sont :
         - list_x, la liste des points x(t_k),
         - list_t, la liste des instants t_k.
-        
+
     Exemples d'appel :
         - euler(lambda x,t : np.cos(t), np.float64(0), 0, 2*np.pi, 100),
         - euler(lambda x,t : np.array([np.cos(t),np.sin(t)]), np.array([0,0]), 0, 2*np.pi, 100),
@@ -187,24 +187,22 @@ def euler(f, x0, t0, tm, m, output=""):
           x = np.array([2,1])
           list_x, list_t = euler(f, x, 0, 10, 100).
     """
-    
+
     # Test des paramètres et définition de la destination de sortie des itérations
     if check_type_arguments.check_real(x0)[0]:
         x0 = np.float64(x0)
     check_parameters_consistency(f, x0, t0, tm, m, output)
     write_iter, write_stopping = writing_function.define_writing_function(format_iter, output)
-    
+
     # Initialisation de l'algorithme
     k, x, t, h, list_x, list_t = init_algo(x0, t0, tm, m)
     write_iter(k, x, t)
-    
+
     # Déroulement de l'algorithme
     while not(stopping_criteria(k, m)[0]):
         k, x, t, list_x, list_t = iter_algo(f, k, x, t, h, list_x, list_t)
         write_iter(k, x, t)
-    
+
     write_stopping(stopping_criteria(k, m)[1])
     # Renvoi de la liste des approximations de la racine, des valeurs de f associées, et des erreurs relatives
     return(list_x, list_t)
-
-

--- a/MTH2210/EDO/rk4.py
+++ b/MTH2210/EDO/rk4.py
@@ -29,7 +29,7 @@ def check_parameters_consistency(f, x0, t0, tm, m, output):
                     [x0,     "x0",     [np.ndarray, np.float64]],
                     [t0,     "t0",     np.float64],
                     [tm,     "tm",     np.float64],
-                    [m,      "m",      np.int],
+                    [m,      "m",      int],
                     [output, "output", str]]
     check_type_arguments.check_parameters(params_array)
     # Vérification de la cohérence des paramètres
@@ -76,7 +76,7 @@ def format_iter(k, x_k, t_k):
             header = ""
         iter_infos = "{:>4} || {:>+11.4e} | {:>+9.4f}"
         iter_infos = iter_infos.format(k, x_k, t_k)
-    
+
     else:
         if k == 0:
             n = len(x_k)
@@ -90,7 +90,7 @@ def format_iter(k, x_k, t_k):
             header = ""
         iter_infos  = "{:>4} || ".format(k)
         iter_infos += "["+", ".join(["{:>+11.4e}".format(xi) for xi in x_k])+"] | "+"{:>+9.4f}".format(t_k)
-    
+
     return(header+iter_infos)
 
 
@@ -149,23 +149,23 @@ def rk4(f, x0, t0, tm, m, output=""):
         - y_k^4 = f(x_k+y_k^3*h  , t_k+h  ),
         - x_kp1 = x_k + (y_k^1+2y_k^2+3y_k^3+y_k^4)*h/6,
         - t_kp1 = t_k + h.
-    
+
     Les arguments attendus sont :
         - une fonction f, admettant en entrée un vecteur x et un réel t, renvoyant un vecteur f(x,t),
         - un vecteur x0, condition initiale de l'équation,
         - deux réels t0 et tm, les bornes de l'intervalle de temps sur lequel l'équation est appliquée,
         - un entier m, le pas de discrétisation de [t0,tm], définissant donc h = (tm-t0)/m.
-    
+
     L'argument optionnel est une chaîne de caractères output (défaut = "") qui renvoie les affichages de la fonction vers :
         - la sortie standard si output = "pipe",
         - un fichier ayant pour nom+extension output (le paramètre doit donc contenir l'extension voulue, et le chemin d'accès doit exister),
         - nul part (aucune information écrite ni sauvegardée) si output = "" ou output = "None".
-    
+
     La méthode vérifie les conditions suivantes :
         - la fonction f est définie en (x0,t0) et en (x0,tm),
         - f(x0,t0) renvoie un vecteur de la même dimension et même type que x0,
         - tous les paramètres reçus ont bien le type attendu.
-    
+
     À noter que si x est un vecteur de dim 1, f doit être implémentée avec parcimonie pour ne pas renvoyer un mauvais type. Par exemple :
         - x = np.array(0) est un np.ndarray, x = np.array([0]) également,
         - f(x,t) = np.cos(np.array(0))   est un np.float64,
@@ -181,11 +181,11 @@ def rk4(f, x0, t0, tm, m, output=""):
         - cas sans garantie de fonctionnement correct :
             - x      complexe,
             - x      de dimension 1 défini par un np.array([valeur]).
-    
+
     Les sorties de la méthode sont :
         - list_x, la liste des points x(t_k),
         - list_t, la liste des instants t_k.
-        
+
     Exemples d'appel :
         - rk4(lambda x,t : np.cos(t), np.float64(0), 0, 2*np.pi, 100),
         - rk4(lambda x,t : np.array([np.cos(t),np.sin(t)]), np.array([0,0]), 0, 2*np.pi, 100),
@@ -195,24 +195,22 @@ def rk4(f, x0, t0, tm, m, output=""):
           x = np.array([2,1])
           list_x, list_t = rk4(f, x, 0, 10, 100).
     """
-    
+
     # Test des paramètres et définition de la destination de sortie des itérations
     if check_type_arguments.check_real(x0)[0]:
         x0 = np.float64(x0)
     check_parameters_consistency(f, x0, t0, tm, m, output)
     write_iter, write_stopping = writing_function.define_writing_function(format_iter, output)
-    
+
     # Initialisation de l'algorithme
     k, x, t, h, list_x, list_t = init_algo(x0, t0, tm, m)
     write_iter(k, x, t)
-    
+
     # Déroulement de l'algorithme
     while not(stopping_criteria(k, m)[0]):
         k, x, t, list_x, list_t = iter_algo(f, k, x, t, h, list_x, list_t)
         write_iter(k, x, t)
-    
+
     write_stopping(stopping_criteria(k, m)[1])
     # Renvoi de la liste des approximations de la racine, des valeurs de f associées, et des erreurs relatives
     return(list_x, list_t)
-
-

--- a/MTH2210/Module_coeur/check_type_arguments.py
+++ b/MTH2210/Module_coeur/check_type_arguments.py
@@ -53,9 +53,9 @@ def check_function(arg):
 def check_str(arg):
     return(check_fundamental(arg, str))
 
-# Renvoie un couple (bool, type) où (bool = True si et seulement si arg est un int, float, np.int ou np.float64); et (type est le type de arg)
+# Renvoie un couple (bool, type) où (bool = True si et seulement si arg est un int, float, int ou np.float64); et (type est le type de arg)
 def check_real(arg):
-    if check_fundamental(arg, np.int)[0] == True:
+    if check_fundamental(arg, int)[0] == True:
         return(True, get_type(arg))
     elif check_fundamental(arg, np.float64)[0] == True:
         return(True, get_type(arg))
@@ -66,7 +66,7 @@ def check_real(arg):
     else:
         return(False, get_type(arg))
 
-# Renvoie un couple (bool, type) où (bool = True si et seulement si arg est un int ou np.int); et (type est le type de arg)
+# Renvoie un couple (bool, type) où (bool = True si et seulement si arg est un int ou int); et (type est le type de arg)
 def check_int(arg):
     return(check_fundamental(arg, int))
 
@@ -86,7 +86,7 @@ def check_generic(arg, expected_type):
         return(check_str(arg))
     if expected_type == np.float64:
         return(check_real(arg))
-    if expected_type == np.int:
+    if expected_type == int:
         return(check_int(arg))
     if expected_type == np.ndarray:
         return(check_nparray(arg))
@@ -133,5 +133,3 @@ def check_parameters(args_list):
     if buffer_errors != []:
         buffer_errors = "\n".join(["Problèmes de type des paramètres :"]+buffer_errors)
         raise ValueError(buffer_errors)
-
-

--- a/MTH2210/Racines_points_fixes/bissection.py
+++ b/MTH2210/Racines_points_fixes/bissection.py
@@ -28,7 +28,7 @@ def check_parameters_consistency(f, x0, x1, nb_iter, tol_rel, tol_abs, output):
     params_array = [[f,       "f",       types.FunctionType],
                     [x0,      "x0",      np.float64],
                     [x1,      "x1",      np.float64],
-                    [nb_iter, "nb_iter", np.int],
+                    [nb_iter, "nb_iter", int],
                     [tol_rel, "tol_rel", np.float64],
                     [tol_abs, "tol_abs", np.float64],
                     [output,  "output",  str]]
@@ -142,11 +142,11 @@ def bissection(f, x0, x1, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""
         - si f(x_g)*f(x_c) < 0, alors la méthode est relancée avec x_g inchangé et x_d = x_c,
         - si f(x_c)*f(x_d) < 0, alors la méthode est relancée avec x_g = x_c et x_d inchangé,
         - à chaque itération k, le point noté x_k est x_c.
-    
+
     Les arguments attendus sont :
         - une fonction f, supposée continue, admettant en entrée un scalaire x et renvoyant un scalaire f(x),
         - deux scalaires x0 et x1 (de type int, float ou np.float64), les bornes de l'intervalle de recherche contenant la racine à localiser.
-    
+
     Les arguments optionnels sont :
         - un entier nb_iter (défaut = 100 ) définissant le nombre maximal d'itérations allouées à l'algorithme,
         - un réel   tol_rel (défaut = 1e-8) définissant la condition d'arrêt abs(x_k-x_km1) / (abs(x_k)+eps) <= tol_rel,
@@ -161,32 +161,30 @@ def bissection(f, x0, x1, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""
         - f est définie en x0 et x1, et renvoie en chacun de ces points un scalaire,
         - nb_iter, tol_rel et tol_abs sont positifs,
         - tous les paramètres reçus ont bien le type attendu.
-    
+
     Les sorties de la méthode sont :
         - list_x, la liste des points centraux de l'intervalle de recherche à chaque itération (donc les approximations x_k de la racine),
         - list_f, les valeurs par f des éléments de list_x.
-        
+
     Exemples d'appel :
         - bissection(lambda x : np.sin(x), -0.5, 1/3),
         - bissection(lambda x : 10**20*np.sin(x), -0.5, 0.25),
         - bissection(f, x0, x1, output="dossier_test/Résultats.txt") où f est définie via def, x0 et x1 sont deux réels.
     """
-    
+
     # Test des paramètres et définition de la destination de sortie des itérations
     check_parameters_consistency(f, x0, x1, nb_iter, tol_rel, tol_abs, output)
     write_iter, write_stopping = writing_function.define_writing_function(format_iter, output)
-    
+
     # Initialisation de l'algorithme
     k, x_g, x_d, x_c, f_g, f_d, f_c, list_x, list_f = init_algo(f, x0, x1)
     write_iter(k, x_g, x_d, f_g, f_d, x_c, f_c)
-    
+
     # Déroulement de l'algorithme
     while not(stopping_criteria(k, list_x, list_f, nb_iter, tol_abs, tol_rel)[0]):
         k, x_g, x_d, x_c, f_g, f_d, f_c, list_x, list_f = iter_algo(f, k, x_g, x_d, x_c, f_g, f_d, f_c, list_x, list_f)
         write_iter(k, x_g, x_d, f_g, f_d, x_c, f_c)
-    
+
     write_stopping(stopping_criteria(k, list_x, list_f, nb_iter, tol_abs, tol_rel)[1])
     # Renvoi de la liste des approximations de la racine, des valeurs de f associées, et des erreurs relatives
     return(list_x, list_f)
-
-

--- a/MTH2210/Racines_points_fixes/newton_1d.py
+++ b/MTH2210/Racines_points_fixes/newton_1d.py
@@ -28,7 +28,7 @@ def check_parameters_consistency(f, df, x0, nb_iter, tol_rel, tol_abs, output):
     params_array = [[f,       "f",       types.FunctionType],
                     [df,      "df",      types.FunctionType],
                     [x0,      "x0",      np.float64],
-                    [nb_iter, "nb_iter", np.int],
+                    [nb_iter, "nb_iter", int],
                     [tol_rel, "tol_rel", np.float64],
                     [tol_abs, "tol_abs", np.float64],
                     [output,  "output",  str]]
@@ -132,12 +132,12 @@ def newton_1d(f, df, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output="")
     """Méthode de recherche d'une racine de la fonction scalaire f via la méthode de Newton :
         - x_0 donné,
         - x_kp1 = xk - f(xk)/f'(xk).
-    
+
     Les arguments attendus sont :
         - une fonction  f, admettant en entrée un scalaire x et renvoyant un scalaire f(x),
         - une fonction df, admettant en entrée un scalaire x et renvoyant un scalaire f'(x),
         - un scalaire  x0 (de type int, float ou np.float64), point de départ de la méthode itérative.
-    
+
     Les arguments optionnels sont :
         - un entier nb_iter (défaut = 100 ) définissant le nombre maximal d'itérations allouées à la méthode,
         - un réel   tol_rel (défaut = 1e-8) définissant la condition d'arrêt abs(x_k-x_km1) / (abs(x_k)+eps) <= tol_rel,
@@ -151,32 +151,30 @@ def newton_1d(f, df, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output="")
          - f est définie en x0, et renvoie un scalaire,
         - df est définie en x0, et renvoie un scalaire,
         - tous les paramètres reçus ont bien le type attendu.
-    
+
     Les sorties de la méthode sont :
         - list_x, la liste des points x_k,
         - list_f, les valeurs par  f des éléments de list_x,
         - list_d, les valeurs par df des éléments de list_x.
-        
+
     Exemples d'appel :
         - newton_1d(lambda x : np.sin(x), lambda x:np.cos(x), 1),
         - newton_1d(lambda x :x**2, lambda x:2*x, 1).
     """
-    
+
     # Test des paramètres et définition de la destination de sortie des itérations
     check_parameters_consistency(f, df, x0, nb_iter, tol_rel, tol_abs, output)
     write_iter, write_stopping = writing_function.define_writing_function(format_iter, output)
-    
+
     # Initialisation de l'algorithme
     k, list_x, list_f, list_d = init_algo(f, df, x0)
     write_iter(k, list_x, list_f, list_d)
-    
+
     # Déroulement de l'algorithme
     while not(stopping_criteria(k, list_x, list_f, list_d, nb_iter, tol_rel, tol_abs)[0]):
         k, list_x, list_f, list_d = iter_algo(f, df, k, list_x, list_f, list_d)
         write_iter(k, list_x, list_f, list_d)
-    
+
     write_stopping(stopping_criteria(k, list_x, list_f, list_d, nb_iter, tol_rel, tol_abs)[1])
     # Renvoi de la liste des approximations de la racine, des valeurs de f associées, et des erreurs relatives
     return(list_x, list_f, list_d)
-
-

--- a/MTH2210/Racines_points_fixes/newton_nd.py
+++ b/MTH2210/Racines_points_fixes/newton_nd.py
@@ -27,7 +27,7 @@ def check_parameters_consistency(f, x0, nb_iter, tol_rel, tol_abs, output):
     # Vérification des types des paramètres reçus
     params_array = [[f,       "f",       types.FunctionType],
                     [x0,      "x0",      np.ndarray],
-                    [nb_iter, "nb_iter", np.int],
+                    [nb_iter, "nb_iter", int],
                     [tol_rel, "tol_rel", np.float64],
                     [tol_abs, "tol_abs", np.float64],
                     [output,  "output",  str]]
@@ -103,14 +103,14 @@ def app_jac(f,x):
     n = np.size(x)
     h_init = 10**-6 if np.min(x) == 0 else 10**-3*np.min(x)
     app_list = [np.zeros((n,n)), np.zeros((n,n))]
-    
+
     for i in range(len(app_list)):
         h = h_init / 2**i
         for d in range(n):
             delta_h = np.zeros(n)
             delta_h[d] = h
             app_list[i][:,d] = (f(x+delta_h) - f(x-delta_h)) / (2*h)
-    
+
     app = (2**2*app_list[1] - app_list[0]) / (2**2-1)
     return(app)
 
@@ -153,11 +153,11 @@ def newton_nd(f, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""):
     """Méthode de recherche d'une racine de la fonction vectorielle f via la méthode de Newton avec approximation de la jacobienne :
         - x_0 donné,
         - x_kp1 = xk - Jac(f)(x_k)^-1*f(x_k).
-    
+
     Les arguments attendus sont :
         - une fonction  f, admettant en entrée un vecteur x et renvoyant un vecteur f(x),
         - un scalaire  x0 (de type int, float ou np.float64), point de départ de la méthode itérative.
-    
+
     Les arguments optionnels sont :
         - un entier nb_iter (défaut = 100 ) définissant le nombre maximal d'itérations allouées à la méthode,
         - un réel   tol_rel (défaut = 1e-8) définissant la condition d'arrêt abs(x_k-x_km1) / (abs(x_k)+eps) <= tol_rel,
@@ -170,12 +170,12 @@ def newton_nd(f, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""):
     La méthode vérifie les conditions suivantes :
          - f est définie en x0, et renvoie un vecteur de même dimension que x0,
          - tous les paramètres reçus ont bien le type attendu.
-    
+
     Les sorties de la méthode sont :
         - list_x, la liste des points x_k,
         - list_f, les valeurs par     f  des éléments de list_x,
         - list_d, les valeurs par Jac(f) des éléments de list_x.
-        
+
     Exemples d'appel :
         - newton_nd(lambda x:x**2, np.array([1,1,1])),
         - def f(x):
@@ -183,22 +183,20 @@ def newton_nd(f, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""):
           x0 = np.array([1,1,1])
           newton_nd(f, x0).
     """
-    
+
     # Test des paramètres et définition de la destination de sortie des itérations
     check_parameters_consistency(f, x0, nb_iter, tol_rel, tol_abs, output)
     write_iter, write_stopping = writing_function.define_writing_function(format_iter, output)
-    
+
     # Initialisation de l'algorithme
     k, list_x, list_f, list_d = init_algo(f, x0)
     write_iter(k, list_x, list_f)
-    
+
     # Déroulement de l'algorithme
     while not(stopping_criteria(k, list_x, list_f, list_d, nb_iter, tol_rel, tol_abs)[0]):
         k, list_x, list_f, list_d = iter_algo(f, k, list_x, list_f, list_d)
         write_iter(k, list_x, list_f)
-    
+
     write_stopping(stopping_criteria(k, list_x, list_f, list_d, nb_iter, tol_rel, tol_abs)[1])
     # Renvoi de la liste des approximations de la racine, des valeurs de f associées, et des erreurs relatives
     return(list_x, list_f, list_d)
-
-

--- a/MTH2210/Racines_points_fixes/newton_nd_avec_der.py
+++ b/MTH2210/Racines_points_fixes/newton_nd_avec_der.py
@@ -28,7 +28,7 @@ def check_parameters_consistency(f, jac, x0, nb_iter, tol_rel, tol_abs, output):
     params_array = [[f,       "f",       types.FunctionType],
                     [jac,     "jac",     types.FunctionType],
                     [x0,      "x0",      np.ndarray],
-                    [nb_iter, "nb_iter", np.int],
+                    [nb_iter, "nb_iter", int],
                     [tol_rel, "tol_rel", np.float64],
                     [tol_abs, "tol_abs", np.float64],
                     [output,  "output",  str]]
@@ -141,12 +141,12 @@ def newton_nd_avec_der(f, jac, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, 
     """Méthode de recherche d'une racine de la fonction vectorielle f via la méthode de Newton avec approximation de la jacobienne :
         - x_0 donné,
         - x_kp1 = xk - Jac(f)(x_k)^-1*f(x_k).
-    
+
     Les arguments attendus sont :
         - une fonction   f, admettant en entrée un vecteur x et renvoyant un  vecteur f(x),
         - une fonction jac, admettant en entrée un vecteur x et renvoyant une matrice Jac(f)(x),
         - un scalaire   x0 (de type int, float ou np.float64), point de départ de la méthode itérative.
-    
+
     Les arguments optionnels sont :
         - un entier nb_iter (défaut = 100 ) définissant le nombre maximal d'itérations allouées à la méthode,
         - un réel   tol_rel (défaut = 1e-8) définissant la condition d'arrêt abs(x_k-x_km1) / (abs(x_k)+eps) <= tol_rel,
@@ -160,12 +160,12 @@ def newton_nd_avec_der(f, jac, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, 
          -   f est définie en x0, et renvoie un  vecteur de même dimension que x0,
          - jac est définie en x0, et renvoie une matrice carrée de dimension dim(x0)*dim(x0),
          - tous les paramètres reçus ont bien le type attendu.
-    
+
     Les sorties de la méthode sont :
         - list_x, la liste des points x_k,
         - list_f, les valeurs par     f  des éléments de list_x,
         - list_d, les valeurs par Jac(f) des éléments de list_x.
-        
+
     Exemples d'appel :
         - newton_nd(lambda x:x**2, lambda x: np.array([2*x]), np.array([1,1,1])),
         - def f(x):
@@ -175,22 +175,20 @@ def newton_nd_avec_der(f, jac, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, 
           x0 = np.array([1,1,1])
           newton_nd_avec_der(f, jac, x0).
     """
-    
+
     # Test des paramètres et définition de la destination de sortie des itérations
     check_parameters_consistency(f, jac, x0, nb_iter, tol_rel, tol_abs, output)
     write_iter, write_stopping = writing_function.define_writing_function(format_iter, output)
-    
+
     # Initialisation de l'algorithme
     k, list_x, list_f, list_d = init_algo(f, jac, x0)
     write_iter(k, list_x, list_f)
-    
+
     # Déroulement de l'algorithme
     while not(stopping_criteria(k, list_x, list_f, list_d, nb_iter, tol_rel, tol_abs)[0]):
         k, list_x, list_f, list_d = iter_algo(f, jac, k, list_x, list_f, list_d)
         write_iter(k, list_x, list_f)
-    
+
     write_stopping(stopping_criteria(k, list_x, list_f, list_d, nb_iter, tol_rel, tol_abs)[1])
     # Renvoi de la liste des approximations de la racine, des valeurs de f associées, et des erreurs relatives
     return(list_x, list_f, list_d)
-
-

--- a/MTH2210/Racines_points_fixes/point_fixe.py
+++ b/MTH2210/Racines_points_fixes/point_fixe.py
@@ -27,7 +27,7 @@ def check_parameters_consistency(f, x0, nb_iter, tol_rel, tol_abs, output):
     # Vérification des types des paramètres reçus
     params_array = [[f,       "f",       types.FunctionType],
                     [x0,      "x0",      [np.ndarray, np.float64]],
-                    [nb_iter, "nb_iter", np.int],
+                    [nb_iter, "nb_iter", int],
                     [tol_rel, "tol_rel", np.float64],
                     [tol_abs, "tol_abs", np.float64],
                     [output,  "output",  str]]
@@ -64,7 +64,7 @@ def check_parameters_consistency(f, x0, nb_iter, tol_rel, tol_abs, output):
 
 # Crée la chaîne de caractères qui sera renvoyée pour chaque itération
 def format_iter(k, x_k, f_k):
-    
+
     if type(x_k) == np.float64:
         if k == 0:
             header  = "{:>4} || {:^11} | {:^11} | {:^11}"
@@ -76,7 +76,7 @@ def format_iter(k, x_k, f_k):
             header = ""
         iter_infos = "{:>4} || {:>+11.4e} | {:>+11.4e} | {:>+11.4e}"
         iter_infos = iter_infos.format(k, abs(x_k-f_k), x_k, f_k)
-    
+
     else:
         if k == 0:
             n = len(x_k)
@@ -92,7 +92,7 @@ def format_iter(k, x_k, f_k):
         iter_infos += "{:>+13.4e} | ".format(np.linalg.norm(x_k-f_k))
         iter_infos += "["+", ".join(["{:>+11.4e}".format(xi) for xi in x_k])+"] | "
         iter_infos += "["+", ".join(["{:>+11.4e}".format(xi) for xi in f_k])+"]"
-    
+
     return(header+iter_infos)
 
 
@@ -146,11 +146,11 @@ def point_fixe(f, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""):
     """Méthode de calcul d'un point fixe x=f(x) par méthode itérative :
         - x_0 donné,
         - x_kp1 = f(x_k).
-    
+
     Les arguments attendus sont :
         - une fonction f, admettant en entrée un vecteur x, renvoyant un vecteur f(x) de même dimension que x,
         - un vecteur x0, point de départ de la méthode itérative.
-    
+
     Les arguments optionnels sont :
         - un entier nb_iter (défaut = 100 ) définissant le nombre maximal d'itérations allouées à la méthode,
         - un réel   tol_rel (défaut = 1e-8) définissant la condition d'arrêt abs(x_k-x_km1) / (abs(x_k)+eps) <= tol_rel,
@@ -159,12 +159,12 @@ def point_fixe(f, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""):
             - la sortie standard si output = "pipe",
             - un fichier ayant pour nom+extension output (le paramètre doit donc contenir l'extension voulue, et le chemin d'accès doit exister),
             - nul part (aucune information écrite ni sauvegardée) si output = "" ou output = "None".
-    
+
     La méthode vérifie les conditions suivantes :
         - la fonction f est définie en x0,
         - norm(f(x0)-x0) >= norm(f(f(x0)-f(x0))) (/!\ vérification de cette condition enlevée en avril 2021 /!\)
         - f(x0) renvoie un vecteur de la même dimension que x0.
-    
+
     À noter que si x est un vecteur de dim 1, f doit être implémentée avec parcimonie pour ne pas renvoyer un mauvais type. Par exemple, en définissant :
         - x = np.array(1) est un np.ndarray, x = np.array([1]) également,
         - f(x) = np.cos(x)           est un np.float64,
@@ -180,34 +180,32 @@ def point_fixe(f, x0, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""):
         - cas sans garantie de fonctionnement correct :
             - x    complexe,
             - x    de dimension 1 défini par un np.array([valeur]).
-    
+
     Les sorties de la méthode sont :
         - list_x,  la liste des points x_k,
         - err_rel, la liste des approximations de l'erreur relative à chaque itération (prenant pour référence le dernier élément de list_x).
-        
+
     Exemples d'appel :
         - point_fixe(lambda x : x**2, 0.5),
         - point_fixe(lambda x : x**2, np.array([0.1,0.1])).
     """
-    
+
     # Test des paramètres et définition de la destination de sortie des itérations
     if check_type_arguments.check_real(x0)[0]:
         x0 = np.float64(x0)
     check_parameters_consistency(f, x0, nb_iter, tol_rel, tol_abs, output)
     write_iter, write_stopping = writing_function.define_writing_function(format_iter, output)
-    
+
     # Initialisation de l'algorithme
     k, x, fx, list_x = init_algo(f, x0)
     write_iter(k, x, fx)
-    
+
     # Déroulement de l'algorithme
     while not(stopping_criteria(f, k, list_x, nb_iter, tol_rel, tol_abs)[0]):
         k, x, fx, list_x = iter_algo(f, k, x, list_x)
         write_iter(k, x, fx)
     err_rel = np.array( [abs(xi-list_x[-1]) for xi in list_x] )
-    
+
     write_stopping(stopping_criteria(f, k, list_x, nb_iter, tol_rel, tol_abs)[1])
     # Renvoi de la liste des approximations de la racine, des valeurs de f associées, et des erreurs relatives
     return(list_x, err_rel)
-
-

--- a/MTH2210/Racines_points_fixes/secante.py
+++ b/MTH2210/Racines_points_fixes/secante.py
@@ -28,7 +28,7 @@ def check_parameters_consistency(f, x0, x1, nb_iter, tol_rel, tol_abs, output):
     params_array = [[f,       "f",       types.FunctionType],
                     [x0,      "x0",      np.float64],
                     [x1,      "x1",      np.float64],
-                    [nb_iter, "nb_iter", np.int],
+                    [nb_iter, "nb_iter", int],
                     [tol_rel, "tol_rel", np.float64],
                     [tol_abs, "tol_abs", np.float64],
                     [output,  "output",  str]]
@@ -138,11 +138,11 @@ def secante(f, x0, x1, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""):
         - x_0 et x_1 donnés,
         - d_k = (f(x_k)-f(x_km1)) / (x_k-x_km1),
         - x_kp1 = x_k - f(x_k) / d_k.
-    
+
     Les arguments attendus sont :
         - une fonction f, admettant en entrée un scalaire x et renvoyant un scalaire f(x),
         - deux scalaires x0 et x1 (de type int, float ou np.float64), points de départ de la méthode itérative.
-    
+
     Les arguments optionnels sont :
         - un entier nb_iter (défaut = 100 ) définissant le nombre maximal d'itérations allouées à la méthode,
         - un réel   tol_rel (défaut = 1e-8) définissant la condition d'arrêt abs(x_k-x_km1) / (abs(x_k)+eps) <= tol_rel,
@@ -156,32 +156,30 @@ def secante(f, x0, x1, nb_iter=100, tol_rel=10**-8, tol_abs=10**-8, output=""):
         - f est définie en x0 et x1, et renvoie un scalaire,
         - df est définie en x0 et x1, et renvoie un scalaire,
         - tous les paramètres reçus ont bien le type attendu.
-    
+
     Les sorties de la méthode sont :
         - list_x, la liste des points x_k,
         - list_f, les valeurs par f des éléments de list_x,
         - list_d, la liste des approximations d_k des dérivées de f en les x_k.
-        
+
     Exemples d'appel :
         - secante(lambda x : np.sin(x), 1, 0.5),
         - secante(lambda x :x**2, 2, 1).
     """
-    
+
     # Test des paramètres et définition de la destination de sortie des itérations
     check_parameters_consistency(f, x0, x1, nb_iter, tol_rel, tol_abs, output)
     write_iter, write_stopping = writing_function.define_writing_function(format_iter, output)
-    
+
     # Initialisation de l'algorithme
     k, list_x, list_f, list_d = init_algo(f, x0, x1)
     write_iter(k, list_x, list_f, list_d)
-    
+
     # Déroulement de l'algorithme
     while not(stopping_criteria(k, list_x, list_f, list_d, nb_iter, tol_rel, tol_abs)[0]):
         k, list_x, list_f, list_d = iter_algo(f, k, list_x, list_f, list_d)
         write_iter(k, list_x, list_f, list_d)
-    
+
     write_stopping(stopping_criteria(k, list_x, list_f, list_d, nb_iter, tol_rel, tol_abs)[1])
     # Renvoi de la liste des approximations de la racine, des valeurs de f associées, et des erreurs relatives
     return(list_x, list_f, list_d)
-
-


### PR DESCRIPTION
[Release notes](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) indicating the deprecation

J'ai dû changer les np.int pour des int (les autres changements sont juste des changements d'espaces) pour utiliser la librairie.

Plutôt que recommander un environnement compliqué, pourquoi ne pas recommander d'executer `pip install -e path/to/downloaded/mth2210.py`?

Finalement, je suggère de remplacer une bonne partie de ces fonctions par leurs équivalents standards: plutôt que d'installer cette librairie du cours, on pourrait juste faire installer scipy, qui offre tout ce qu'il faut:

lagrange: [scipy.interpolate.lagrange](https://scipy.github.io/devdocs/reference/generated/scipy.interpolate.lagrange.html)
bissection: [scipy.optimize.bisect](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.bisect.html)
euler: scipy.integrate.ode
newton*: [scipy.optimize.newton](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.newton.html)
point_fixe: Il n'y a pas d'alternative que je connaisse à celle-là, mais est-elle trop complexe pour être implémentée par nous-mêmes?
RK4: [scipy.integrate.RK45](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.RK45.html#scipy.integrate.RK45)


